### PR TITLE
Prevent blank page on first load before Admin install

### DIFF
--- a/includes/classes/OnePageCheckout.php
+++ b/includes/classes/OnePageCheckout.php
@@ -358,7 +358,7 @@ class OnePageCheckout extends base
         $this->guestCustomerId = (defined('CHECKOUT_ONE_GUEST_CUSTOMER_ID')) ? (int)CHECKOUT_ONE_GUEST_CUSTOMER_ID : 0;
         $this->tempBilltoAddressBookId = (defined('CHECKOUT_ONE_GUEST_BILLTO_ADDRESS_BOOK_ID')) ? (int)CHECKOUT_ONE_GUEST_BILLTO_ADDRESS_BOOK_ID : 0;
         $this->tempSendtoAddressBookId = (defined('CHECKOUT_ONE_GUEST_SENDTO_ADDRESS_BOOK_ID')) ? (int)CHECKOUT_ONE_GUEST_SENDTO_ADDRESS_BOOK_ID : 0;
-        $this->registeredAccounts = (CHECKOUT_ONE_ENABLE_REGISTERED_ACCOUNTS === 'true');
+        $this->registeredAccounts = (defined('CHECKOUT_ONE_ENABLE_REGISTERED_ACCOUNTS') && CHECKOUT_ONE_ENABLE_REGISTERED_ACCOUNTS === 'true');
         
         // -----
         // The 'stringIgnoreNull' type of database "bind" type was introduced in ZC1.5.5b; if the store


### PR DESCRIPTION
On a brand new store without OPC installed, after merely copying all the files to the server (before loading the Admin page to trigger the "Install"), a blank page may occur when PHP is operating in strict mode (as is PHP 8.0), and will be described in catalog logs as:

```
PHP Fatal error:  Uncaught Error: Undefined constant "CHECKOUT_ONE_ENABLE_REGISTERED_ACCOUNTS" in /includes/classes/OnePageCheckout.php:361
Stack trace:
#0 /includes/classes/OnePageCheckout.php(473): OnePageCheckout->initializeGuestCheckout()
#1 /includes/classes/OnePageCheckout.php(437): OnePageCheckout->reset()
#2 /includes/classes/observers/class.checkout_one_observer.php(46): OnePageCheckout->resetGuestSessionValues()
#3 /includes/autoload_func.php(44): checkout_one_observer->__construct()
  thrown in /includes/classes/OnePageCheckout.php on line 361
```