### PR TITLE
Prevent "Free shipping over $0.00" when 0 threshold

### DIFF
--- a/includes/templates/template_default/templates/tpl_modules_opc_shipping_choices.php
+++ b/includes/templates/template_default/templates/tpl_modules_opc_shipping_choices.php
@@ -37,7 +37,10 @@ if ($is_virtual_order) {
         if ($free_shipping == true) {
 ?>
         <div id="freeShip" class="important" ><?php echo FREE_SHIPPING_TITLE; ?></div>
-        <div id="defaultSelected"><?php echo sprintf(FREE_SHIPPING_DESCRIPTION, $currencies->format(MODULE_ORDER_TOTAL_SHIPPING_FREE_SHIPPING_OVER)) . zen_draw_hidden_field('shipping', 'free_free'); ?></div>
+        <div id="defaultSelected">
+            <?php if (!empty(MODULE_ORDER_TOTAL_SHIPPING_FREE_SHIPPING_OVER)) echo sprintf(FREE_SHIPPING_DESCRIPTION, $currencies->format(MODULE_ORDER_TOTAL_SHIPPING_FREE_SHIPPING_OVER)); ?>
+        </div>
+        <?php echo zen_draw_hidden_field('shipping', 'free_free'); ?>
 
 <?php
         } else {


### PR DESCRIPTION
When `free_free` has a minimum threshold, the displayed description outputs that amount. 
When the threshold is `$0.00` it shouldn't output the threshold.

Possible improvement, which requires other changes to language files, could include outputting a different description instead of suppressing it like this PR does.
One could consider pulling a define from another module, but that could get messy.