### PR TITLE
Remove duplicate constant definition

### DIFF
--- a/includes/languages/english/modules/order_total/YOUR_TEMPLATE/ot_coupon.php
+++ b/includes/languages/english/modules/order_total/YOUR_TEMPLATE/ot_coupon.php
@@ -11,7 +11,6 @@
   define('MODULE_ORDER_TOTAL_COUPON_HEADER', TEXT_GV_NAMES . '/Discount Coupon');
   define('MODULE_ORDER_TOTAL_COUPON_DESCRIPTION', 'Discount Coupon');
   define('MODULE_ORDER_TOTAL_COUPON_TEXT_ENTER_CODE', TEXT_GV_REDEEM);
-  define('MODULE_ORDER_TOTAL_COUPON_HEADER', TEXT_GV_NAMES . '/Discount Coupon');
   define('SHIPPING_NOT_INCLUDED', ' [Shipping not included]');
   define('TAX_NOT_INCLUDED', ' [Tax not included]');
   define('IMAGE_REDEEM_VOUCHER', 'Redeem Voucher');


### PR DESCRIPTION
Old versions of Zen Cart defined the 'MODULE_ORDER_TOTAL_COUPON_HEADER'
constant twice, and both these definitions were copied into the One-Page
Checkout plugin. The bug has since been fixed in Zen Cart by removing
the second definition; this commit does the same thing for One-Page
Checkout.