### PR TITLE
#386: Correct PHP warning for missing $fax variable

### DIFF
--- a/YOUR_ADMIN/includes/init_includes/init_checkout_one.php
+++ b/YOUR_ADMIN/includes/init_includes/init_checkout_one.php
@@ -15,8 +15,8 @@ if (!defined('IS_ADMIN_FLAG')) {
 // 500-599 ... Registered-account settings
 // 1000+ ..... Debug settings
 //
-define('CHECKOUT_ONE_CURRENT_VERSION', '2.4.6');
-define('CHECKOUT_ONE_CURRENT_UPDATE_DATE', '2023-08-19');
+define('CHECKOUT_ONE_CURRENT_VERSION', '2.4.7-beta1');
+define('CHECKOUT_ONE_CURRENT_UPDATE_DATE', '2023-12-18');
 
 if (isset($_SESSION['admin_id'])) {
     $version_release_date = CHECKOUT_ONE_CURRENT_VERSION . ' (' . CHECKOUT_ONE_CURRENT_UPDATE_DATE . ')';

--- a/docs/one_page_checkout/readme.html
+++ b/docs/one_page_checkout/readme.html
@@ -728,6 +728,13 @@ require DIR_WS_TEMPLATES . 'template_default/jscript/jscript_framework.php';
             <div id="changes">
               <p>You can view the details of these changes on the plugin's <a href="https://github.com/lat9/one_page_checkout/issues" target="_blank" rel="noopener">GitHub repository</a>. <span class="template-changed">Changes to the plugin's default templates are identified in this color</span>; remember to merge those changes with any template-override version you might have created!  Additions are identified by <span class="added">this</span> color and removals are indicated like <span class="removed">this</span>.</p>
               <ul>
+                <li>v2.4.7, 2023-12-18 (lat9):<ul>
+                    <li>BUGFIX: Correct PHP warning for registered-account creation (missing <var>$fax</var>).</li>
+                    <li>The following files were changed or <span class="added">added</span>:<ol>
+                        <li>/includes/modules/pages/create_account/header_php_create_account_register.php</li>
+                        <li>/YOUR_ADMIN/includes/init_includes/init_checkout_one.php</li>
+                    </ol></li>
+                </ul></li>
                 <li>v2.4.6, 2023-08-19 (lat9 and marco-pm):<ul>
                     <li>BUGFIX: Correct unwanted redirect when pricing includes an &amp;nbsp;.</li>
                     <li>BUGFIX: Redirect page correctly on AJAX return.</li>

--- a/includes/modules/pages/create_account/header_php_create_account_register.php
+++ b/includes/modules/pages/create_account/header_php_create_account_register.php
@@ -1,9 +1,9 @@
 <?php
 // -----
 // Part of the One-Page Checkout plugin, provided under GPL 2.0 license by lat9 (cindy@vinosdefrutastropicales.com).
-// Copyright (C) 2017-2022, Vinos de Frutas Tropicales.  All rights reserved.
+// Copyright (C) 2017-2023, Vinos de Frutas Tropicales.  All rights reserved.
 //
-// Last updated: OPC v2.4.5
+// Last updated: OPC v2.4.7
 //
 // This should be first line of the script:
 $zco_notifier->notify('NOTIFY_HEADER_START_CREATE_ACCOUNT_REGISTER');
@@ -134,7 +134,7 @@ if (isset($_POST['action']) && $_POST['action'] === 'register') {
             }
         }
     }
-    
+
     $nick = (isset($_POST['nick'])) ? zen_db_prepare_input($_POST['nick']) : '';
     $nick_length_min = ENTRY_NICK_MIN_LENGTH;
     $zco_notifier->notify('NOTIFY_NICK_CHECK_FOR_MIN_LENGTH', $nick, $nick_error, $nick_length_min);
@@ -183,75 +183,75 @@ if (isset($_POST['action']) && $_POST['action'] === 'register') {
         $db_string_type = $_SESSION['opc']->getDbStringType();
         $sql_data_array = [
             [
-                'fieldName' => 'customers_firstname', 
-                'value' => $firstname, 
+                'fieldName' => 'customers_firstname',
+                'value' => $firstname,
                 'type' => $db_string_type
             ],
             [
-                'fieldName' => 'customers_lastname', 
-                'value' => $lastname, 
+                'fieldName' => 'customers_lastname',
+                'value' => $lastname,
                 'type' => $db_string_type
             ],
             [
-                'fieldName' => 'customers_email_address', 
-                'value' => $email_address, 
+                'fieldName' => 'customers_email_address',
+                'value' => $email_address,
                 'type' => $db_string_type
             ],
             [
-                'fieldName' => 'customers_nick', 
-                'value' => $nick, 
+                'fieldName' => 'customers_nick',
+                'value' => $nick,
                 'type' => $db_string_type
             ],
             [
-                'fieldName' => 'customers_telephone', 
-                'value' => $telephone, 
+                'fieldName' => 'customers_telephone',
+                'value' => $telephone,
                 'type' => $db_string_type
             ],
             [
-                'fieldName' => 'customers_newsletter', 
-                'value' => $newsletter, 
+                'fieldName' => 'customers_newsletter',
+                'value' => $newsletter,
                 'type' => 'integer'
             ],
             [
-                'fieldName' => 'customers_email_format', 
-                'value' => $email_format, 
+                'fieldName' => 'customers_email_format',
+                'value' => $email_format,
                 'type' => $db_string_type
             ],
             [
-                'fieldName' => 'customers_default_address_id', 
-                'value' => 0, 
+                'fieldName' => 'customers_default_address_id',
+                'value' => 0,
                 'type' => 'integer'
             ],
             [
-                'fieldName' => 'customers_password', 
-                'value' => zen_encrypt_password($password), 
+                'fieldName' => 'customers_password',
+                'value' => zen_encrypt_password($password),
                 'type' => $db_string_type
             ],
             [
-                'fieldName' => 'customers_authorization', 
-                'value' => $customers_authorization, 
+                'fieldName' => 'customers_authorization',
+                'value' => $customers_authorization,
                 'type' => 'integer'
             ],
         ];
 
         if ((CUSTOMERS_REFERRAL_STATUS === '2' && $customers_referral !== '')) {
             $sql_data_array[] = [
-                'fieldName' => 'customers_referral', 
-                'value' => $customers_referral, 
+                'fieldName' => 'customers_referral',
+                'value' => $customers_referral,
                 'type' => $db_string_type
             ];
         }
         if (ACCOUNT_GENDER === 'true') {
             $sql_data_array[] = [
-                'fieldName' => 'customers_gender', 
-                'value' => $gender, 
+                'fieldName' => 'customers_gender',
+                'value' => $gender,
                 'type' => $db_string_type
             ];
         }
         if (ACCOUNT_DOB === 'true') {
             $sql_data_array[] = [
-                'fieldName' => 'customers_dob', 
-                'value' => empty($_POST['dob']) ? zen_db_prepare_input('0001-01-01 00:00:00') : zen_date_raw($_POST['dob']), 
+                'fieldName' => 'customers_dob',
+                'value' => empty($_POST['dob']) ? zen_db_prepare_input('0001-01-01 00:00:00') : zen_date_raw($_POST['dob']),
                 'type' => 'date'
             ];
         }
@@ -317,14 +317,14 @@ if (isset($_POST['action']) && $_POST['action'] === 'register') {
         ];
         if (ACCOUNT_GENDER === 'true') {
             $sql_data_array[] = [
-                'fieldName' => 'entry_gender', 
+                'fieldName' => 'entry_gender',
                 'value' => $gender, 
                 'type' => $db_string_type
             ];
         }
         if (ACCOUNT_COMPANY === 'true') {
             $sql_data_array[] = [
-                'fieldName' => 'entry_company', 
+                'fieldName' => 'entry_company',
                 'value' => $company, 
                 'type' => $db_string_type
             ];
@@ -402,9 +402,9 @@ if (isset($_POST['action']) && $_POST['action'] === 'register') {
                         trigger_error('Unknown coupon_id (' . NEW_SIGNUP_DISCOUNT_COUPON . ') during account creation.  The coupon was not sent.', E_USER_WARNING);
                     } else {
                         $db->Execute(
-                            "INSERT INTO " . TABLE_COUPON_EMAIL_TRACK . " 
-                                (coupon_id, customer_id_sent, sent_firstname, emailed_to, date_sent) 
-                             VALUES 
+                            "INSERT INTO " . TABLE_COUPON_EMAIL_TRACK . "
+                                (coupon_id, customer_id_sent, sent_firstname, emailed_to, date_sent)
+                             VALUES
                                 (" . $coupon_id . ", '0', 'Admin', '" . $email_address . "', now() )"
                         );
 
@@ -431,8 +431,8 @@ if (isset($_POST['action']) && $_POST['action'] === 'register') {
             if (NEW_SIGNUP_GIFT_VOUCHER_AMOUNT > 0) {
                 $coupon_code = zen_create_coupon_code();
                 $insert_query = $db->Execute(
-                    "INSERT INTO " . TABLE_COUPONS . " 
-                        (coupon_code, coupon_type, coupon_amount, date_created) 
+                    "INSERT INTO " . TABLE_COUPONS . "
+                        (coupon_code, coupon_type, coupon_amount, date_created)
                      VALUES ('" . $coupon_code . "', 'G', '" . NEW_SIGNUP_GIFT_VOUCHER_AMOUNT . "', now())"
                 );
                 $insert_id = $db->Insert_ID();
@@ -441,13 +441,13 @@ if (isset($_POST['action']) && $_POST['action'] === 'register') {
                 // if on, add in GV explanation
                 $email_text .= 
                     PHP_EOL . PHP_EOL . 
-                    sprintf(EMAIL_GV_INCENTIVE_HEADER, $currencies->format(NEW_SIGNUP_GIFT_VOUCHER_AMOUNT)) . 
+                    sprintf(EMAIL_GV_INCENTIVE_HEADER, $currencies->format(NEW_SIGNUP_GIFT_VOUCHER_AMOUNT)) .
                     sprintf(EMAIL_GV_REDEEM, $coupon_code) .
                     EMAIL_GV_LINK . zen_href_link(FILENAME_GV_REDEEM, 'gv_no=' . $coupon_code, 'NONSSL', false) . PHP_EOL . PHP_EOL .
                     EMAIL_GV_LINK_OTHER . 
                     EMAIL_SEPARATOR;
                 $html_msg['GV_WORTH'] = str_replace('\n', '', sprintf(EMAIL_GV_INCENTIVE_HEADER, $currencies->format(NEW_SIGNUP_GIFT_VOUCHER_AMOUNT)) );
-                $html_msg['GV_REDEEM'] = str_replace('\n', '', str_replace('\n\n','<br />',sprintf(EMAIL_GV_REDEEM, '<strong>' . $coupon_code . '</strong>')));
+                $html_msg['GV_REDEEM'] = str_replace('\n', '', str_replace('\n\n', '<br>',sprintf(EMAIL_GV_REDEEM, '<strong>' . $coupon_code . '</strong>')));
                 $html_msg['GV_CODE_NUM'] = $coupon_code;
                 $html_msg['GV_CODE_URL'] = str_replace('\n', '', EMAIL_GV_LINK . '<a href="' . zen_href_link(FILENAME_GV_REDEEM, 'gv_no=' . $coupon_code, 'NONSSL', false) . '">' . TEXT_GV_NAME . ': ' . $coupon_code . '</a>');
                 $html_msg['GV_LINK_OTHER'] = EMAIL_GV_LINK_OTHER;
@@ -471,7 +471,7 @@ if (isset($_POST['action']) && $_POST['action'] === 'register') {
 
             // send additional emails
             if (SEND_EXTRA_CREATE_ACCOUNT_EMAILS_TO_STATUS === '1' && SEND_EXTRA_CREATE_ACCOUNT_EMAILS_TO !== '') {
-                $extra_info = email_collect_extra_info($name, $email_address, $name, $email_address, $telephone, $fax);
+                $extra_info = email_collect_extra_info($name, $email_address, $name, $email_address, $telephone, $fax ?? '');
                 $html_msg['EXTRA_INFO'] = $extra_info['HTML'];
                 if (trim(SEND_EXTRA_CREATE_ACCOUNT_EMAILS_TO_SUBJECT) !== 'n/a') {
                     zen_mail('', SEND_EXTRA_CREATE_ACCOUNT_EMAILS_TO, SEND_EXTRA_CREATE_ACCOUNT_EMAILS_TO_SUBJECT . ' ' . EMAIL_SUBJECT, $email_text . $extra_info['TEXT'], STORE_NAME, EMAIL_FROM, $html_msg, 'welcome_extra');


### PR DESCRIPTION
- Defaulting to an empty string if not present, just in case the FAX number is added to the registered-account creation in the future.
- Removing stray/unneeded spaces.
- Using HTML5 `<br>` instead of `<br />`.