### PR TITLE
Restructure page reload

### DIFF
--- a/YOUR_ADMIN/includes/init_includes/init_checkout_one.php
+++ b/YOUR_ADMIN/includes/init_includes/init_checkout_one.php
@@ -15,8 +15,8 @@ if (!defined('IS_ADMIN_FLAG')) {
 // 500-599 ... Registered-account settings
 // 1000+ ..... Debug settings
 //
-define('CHECKOUT_ONE_CURRENT_VERSION', '2.5.0-beta1');
-define('CHECKOUT_ONE_CURRENT_UPDATE_DATE', '2024-02-22');
+define('CHECKOUT_ONE_CURRENT_VERSION', '2.5.0-beta2');
+define('CHECKOUT_ONE_CURRENT_UPDATE_DATE', '2024-03-09');
 
 if (isset($_SESSION['admin_id'])) {
     $version_release_date = CHECKOUT_ONE_CURRENT_VERSION . ' (' . CHECKOUT_ONE_CURRENT_UPDATE_DATE . ')';

--- a/YOUR_ADMIN/includes/init_includes/init_checkout_one_upgrade.php
+++ b/YOUR_ADMIN/includes/init_includes/init_checkout_one_upgrade.php
@@ -1,7 +1,9 @@
 <?php
 // -----
 // Part of the One-Page Checkout plugin, provided under GPL 2.0 license by lat9
-// Copyright (C) 2013-2022, Vinos de Frutas Tropicales.  All rights reserved.
+// Copyright (C) 2013-2024, Vinos de Frutas Tropicales.  All rights reserved.
+//
+// Last updated: OPC v2.5.0
 //
 if (!defined('IS_ADMIN_FLAG')) {
     die('Illegal Access');
@@ -363,6 +365,19 @@ switch (true) {
                 SET configuration_description = 'Identify (using a comma-separated list) the payment modules on your store that require confirmation.  If your store requires confirmation on all orders, simply list all payment modules used by your store.<br><br>Use the <code>credit_covers</code> &quot;method&quot; if orders that are fully paid using a Gift Certificate or coupon should also require confirmation.<br><br>Default: <code>eway_rapid,stripepay,gps</code><br>',
                     last_modified = now()
               WHERE configuration_key = 'CHECKOUT_ONE_CONFIRMATION_REQUIRED'
+              LIMIT 1"
+        );
+
+    // -----
+    // v2.5.0:
+    //
+    // - The setting 'CHECKOUT_ONE_PAYMENT_BLOCK_ACTION', since there's no longer a page
+    //   reload when the shipping selection is changed.
+    //
+    case version_compare(CHECKOUT_ONE_MODULE_VERSION, '2.5.0', '<'):    //-Fall-through processing from above
+        $db->Execute(
+            "DELETE FROM " . TABLE_CONFIGURATION . "
+              WHERE configuration_key = 'CHECKOUT_ONE_PAYMENT_BLOCK_ACTION'
               LIMIT 1"
         );
     default:                                                            //-Fall-through processing from above

--- a/includes/classes/OnePageCheckout.php
+++ b/includes/classes/OnePageCheckout.php
@@ -627,7 +627,7 @@ class OnePageCheckout extends base
         }
 
         $current_settings = print_r($this, true);
-        $this->debugMessage('startGuestOnePageCheckout, exit: sendto: ' . ((isset($_SESSION['sendto'])) ? $_SESSION['sendto'] : 'not set') . ', billto: ' . ((isset($_SESSION['billto'])) ? $_SESSION['billto'] : 'not set') . PHP_EOL . $current_settings);
+        $this->debugMessage('startGuestOnePageCheckout, exit: sendto: ' . ($_SESSION['sendto'] ?? 'not set') . ', billto: ' . ($_SESSION['billto'] ?? 'not set') . PHP_EOL . $current_settings);
 
         if ($redirect_required === true) {
             zen_redirect(zen_href_link(FILENAME_CHECKOUT_ONE, '', 'SSL'));
@@ -1438,7 +1438,7 @@ class OnePageCheckout extends base
         $messages = [];
         $this->customerInfoOk = false;
 
-        $email_address = (isset($_POST['email_address'])) ? zen_db_prepare_input(zen_sanitize_string($_POST['email_address'])) : '';
+        $email_address = zen_db_prepare_input(zen_sanitize_string($_POST['email_address'] ?? ''));
         if (strlen($email_address) < ENTRY_EMAIL_ADDRESS_MIN_LENGTH) {
             $messages['email_address'] = ENTRY_EMAIL_ADDRESS_ERROR;
         } elseif (!zen_validate_email($email_address) || $this->isEmailBanned($email_address) === true) {
@@ -1450,7 +1450,7 @@ class OnePageCheckout extends base
             }
         }
 
-        $telephone = (isset($_POST['telephone'])) ? zen_db_prepare_input(zen_sanitize_string($_POST['telephone'])) : '';
+        $telephone = zen_db_prepare_input(zen_sanitize_string($_POST['telephone'] ?? ''));
         if (strlen($telephone) < ENTRY_TELEPHONE_MIN_LENGTH) {
             $messages['telephone'] = ENTRY_TELEPHONE_NUMBER_ERROR;
         }
@@ -1465,7 +1465,7 @@ class OnePageCheckout extends base
         $dob = '';
         $dob_display = '';
         if (ACCOUNT_DOB === 'true') {
-            $dob = (isset($_POST['dob'])) ? zen_db_prepare_input($_POST['dob']) : '';
+            $dob = zen_db_prepare_input($_POST['dob'] ?? '');
             $dob_display = $dob;
             if (ENTRY_DOB_MIN_LENGTH > 0 || !empty($_POST['dob'])) {
                 // Support ISO-8601 style date
@@ -1567,7 +1567,7 @@ class OnePageCheckout extends base
         }
 
         if (ACCOUNT_GENDER === 'true') {
-            $gender = (isset($address_values['gender'])) ? zen_db_prepare_input($address_values['gender']) : '';
+            $gender = zen_db_prepare_input($address_values['gender'] ?? '');
             if ($gender !== 'm' && $gender !== 'f') {
                 $error = true;
                 $messages['gender'] = $message_prefix . ENTRY_GENDER_ERROR;
@@ -1616,8 +1616,8 @@ class OnePageCheckout extends base
             $error = true;
             $messages['zone_country_id'] = $message_prefix . ENTRY_COUNTRY_ERROR;
         } elseif (ACCOUNT_STATE === 'true') {
-            $state = (isset($address_values['state'])) ? trim(zen_db_prepare_input($address_values['state'])) : '';
-            $zone_id = (isset($address_values['zone_id'])) ? zen_db_prepare_input($address_values['zone_id']) : 0;
+            $state = trim(zen_db_prepare_input($address_values['state']) ?? '');
+            $zone_id = zen_db_prepare_input($address_values['zone_id'] ?? 0);
 
             $country_has_zones = $this->countryHasZones((int)$country);
             if ($country_has_zones) {
@@ -2332,7 +2332,7 @@ class OnePageCheckout extends base
                         if ($t === 'customer_name') {
                             $name_pieces = explode(' ', $paypal_ec_payment_info[$pp]);
                             $this->tempAddressValues['ship']['firstname'] = trim($name_pieces[0]);
-                            $this->tempAddressValues['ship']['lastname'] = (isset($name_pieces[1])) ? trim($name_pieces[1]) : '';
+                            $this->tempAddressValues['ship']['lastname'] = trim($name_pieces[1] ?? '');
                         } else {
                             $this->tempAddressValues['ship'][$t] = $paypal_ec_payment_info[$pp];
                         }

--- a/includes/classes/ajax/zcAjaxOnePageCheckout.php
+++ b/includes/classes/ajax/zcAjaxOnePageCheckout.php
@@ -505,13 +505,6 @@ class zcAjaxOnePageCheckout extends base
             $order_total_html = ob_get_clean();
         }
  
-        // -----
-        // Some payment methods, e.g. square, have some external jQuery that is loaded and run on initial
-        // page-load **only**.  Set a processing flag for use by the 'checkout_one' page's jQuery to indicate what
-        // action should be taken for the payment-method HTML on a shipping-method update.
-        //
-        // Possible values are 'update', 'no-update' or 'refresh'.
-        //
         $return_array = [
             'status' => $status,
             'errorMessage' => $error_message,
@@ -519,7 +512,6 @@ class zcAjaxOnePageCheckout extends base
             'shippingHtml' => $shipping_html,
             'shippingMessage' => $shipping_choose_message,
             'paymentHtml' => $payment_html,
-            'paymentHtmlAction' => CHECKOUT_ONE_PAYMENT_BLOCK_ACTION,
         ];
         $session_shipping = (isset($_SESSION['shipping'])) ? json_encode($_SESSION['shipping']) : 'Shipping not set';
         $checkout_one->debug_message('updateShipping, returning:' . json_encode($return_array) . PHP_EOL . $session_shipping);
@@ -745,12 +737,12 @@ class zcAjaxOnePageCheckout extends base
             $shipping_modules = new shipping($_SESSION['shipping']);
 
             require DIR_WS_CLASSES . 'payment.php';
-            $payment_modules = new payment;
+            $payment_modules = new payment();
 
             if (!class_exists('order_total')) {
                 require DIR_WS_CLASSES . 'order_total.php';
             }
-            $order_total_modules = new order_total;
+            $order_total_modules = new order_total();
 
             ob_start();
             $order_total_modules->process();

--- a/includes/classes/ajax/zcAjaxOnePageCheckout.php
+++ b/includes/classes/ajax/zcAjaxOnePageCheckout.php
@@ -24,13 +24,7 @@ class zcAjaxOnePageCheckout extends base
     //
     public function updateShippingSelection()
     {
-        // -----
-        // Since we're running as a function, need to declare the objects we're instantiating here, for use by the various classes
-        // involved in creating the order's total-block.
-        //
-        global $db, $order, $currencies, $checkout_one, $total_weight, $total_count, $discount_coupon, $messageStack;
-        global $shipping_weight, $uninsurable_value, $shipping_quoted, $shipping_num_boxes, $template, $template_dir;
-        global $language_page_directory, $current_page_base;
+        global $checkout_one;
 
         // -----
         // Load the One-Page Checkout page's language files. Note that this method also sets the
@@ -95,53 +89,7 @@ class zcAjaxOnePageCheckout extends base
                         'cost' => $shipping_method_cost,
                     ];
 
-                    // -----
-                    // Create an instance of the order-class, setting the in-cart products
-                    // and their pricing/taxes as well as the updated shipping-selection recorded
-                    // in the session, above.
-                    //
-                    require DIR_WS_CLASSES . 'order.php';
-                    $order = new order();
-
-                    // -----
-                    // Create an instance of the shipping-class; that'll pull in the language files and make
-                    // an instance of all the currently-enabled shipping modules.
-                    //
-                    require DIR_WS_CLASSES . 'shipping.php';
-                    $shipping_modules = new shipping();
-
-                    // -----
-                    // The ot_coupon order-total expects the $discount_coupon variable to be present if
-                    // there's a coupon associated with the order.
-                    //
-                    if (!empty($_SESSION['cc_id'])) {
-                        $discount_coupon_query = "SELECT coupon_code FROM " . TABLE_COUPONS . " WHERE coupon_id = :couponID LIMIT 1";
-                        $discount_coupon_query = $db->bindVars($discount_coupon_query, ':couponID', $_SESSION['cc_id'], 'integer');
-                        $discount_coupon = $db->Execute($discount_coupon_query);
-                    }
-
-                    // -----
-                    // Pull in changes/re-calculations for the order's totals based on the change in
-                    // shipping method.
-                    //
-                    if (!class_exists('order_total')) {
-                        require DIR_WS_CLASSES . 'order_total.php';
-                    }
-                    $order_total_modules = new order_total();
-
-                    ob_start();
-                    $order_total_modules->process();
-                    $_SESSION['opc_order_hash'] = md5(json_encode($order->info));
-                    $order_total_modules->output();
-                    $order_total_html = ob_get_clean();
-
-                    $checkout_one->debug_message(
-                        "Returning:\n" .
-                        json_encode($order->info, JSON_PRETTY_PRINT) . "\n" .
-                        json_encode($_SESSION['shipping']) . "\n",
-                        false,
-                        'zcAjaxOnePageCheckout::updateShippingSelection'
-                    );
+                    $order_total_html = $this->createOrderTotalHtml();
                 }
             }
         }
@@ -157,366 +105,33 @@ class zcAjaxOnePageCheckout extends base
     }
 
     // -----
-    // Update the order's shipping method when the selection has changed on the checkout_one page.
+    // Called by jQuery handling when the shipping=billing checkbox
+    // is changed such that billing and shipping are now the same.
     //
-    public function updateShipping()
+    public function setShippingEqualBilling()
     {
-        // -----
-        // Since we're running as a function, need to declare the objects we're instantiating here, for use by the various classes
-        // involved in creating the order's total-block.
-        //
-        global $db, $order, $currencies, $checkout_one, $total_weight, $total_count, $discount_coupon, $messageStack;
-        global $shipping_weight, $uninsurable_value, $shipping_quoted, $shipping_num_boxes, $template, $template_dir;
-        global $language_page_directory, $current_page_base;
-
         // -----
         // Load the One-Page Checkout page's language files.
         //
         $this->loadLanguageFiles();
 
         $error_message = '';
-        $order_total_html = '';
-        $shipping_html = '';
-        $payment_html = '';
-        $shipping_choose_message = '';
 
         // -----
-        // Initialize the response's status code, continuing only if all is 'ok'.
+        // Initialize the response's status code, continuing only if all is 'ok'.  If
+        // no issues found during status initialization, instruct the jQuery to
+        // reload the checkout_one page if the shipping address was changed by this
+        // request.
         //
-        $status = $this->initializeResponseStatus('updateShipping', $error_message);
-        if ($status === 'ok') {
-            // -----
-            // Include the class required by some of the shipping methods, e.g. USPS.
-            //
-            require_once DIR_WS_CLASSES . 'http_client.php'; 
-
-            $total_count = $_SESSION['cart']->count_contents();
-            $total_weight = $_SESSION['cart']->show_weight();
-            
-            if (!empty($_SESSION['cc_id'])) {
-                $discount_coupon_query = "SELECT coupon_code FROM " . TABLE_COUPONS . " WHERE coupon_id = :couponID LIMIT 1";
-                $discount_coupon_query = $db->bindVars($discount_coupon_query, ':couponID', $_SESSION['cc_id'], 'integer');
-                $discount_coupon = $db->Execute($discount_coupon_query);
-            }
-
-            // -----
-            // Manage the shipping-address, based on the "Shipping Address, Same as Billing?" checkbox value submitted.
-            //
-            // Noting that for a virtual order, the session's already been set-up to reflect that shipping and billing
-            // aren't the same, so nothing further needs to be done for the shipping address.
-            //
-            $checkout_one->debug_message(
-                'Billing/shipping, entry (' . $_POST['shipping_is_billing'] . '), ' .
-                $_SESSION['sendto'] . ', ' .
-                $_SESSION['billto'] . ', (' .
-                $_SESSION['shipping_billing'] . '), (' .
-                $_SESSION['opc']->isVirtualOrder() . ')',
-                false,
-                'zcAjaxOnePageCheckout::updateShipping'
-            );
-
-            // -----
-            // If the order requires shipping ...
-            //
-            $ship_to = 'billing';
-            if ($_SESSION['opc']->isVirtualOrder() === false) {
-                // -----
-                // If the customer has indicated that the order is to be shipped to the
-                // billing address ...
-                //
-                $ship_to = 'shipping';
-                if ($_POST['shipping_is_billing'] === 'true') {
-                    // -----
-                    // ... and the order's currently using a shipping address other than billing ...
-                    //
-                    if ($_SESSION['opc']->getShippingBilling() === false) {
-                        // -----
-                        // Set the order's shipping address to be its billing address and
-                        // indicate as such with the shipping-equals-billing flag.
-                        //
-                        $_SESSION['sendto'] = $_SESSION['billto'];
-                        $_SESSION['shipping_billing'] = true;
-
-                        // -----
-                        // Reset the temporary shipping address to reflect billing.  If
-                        // an out-of-sync condition is detected, a message will be displayed
-                        // to the customer and the checkout_one page will be reloaded by
-                        // its jQuery processing.
-                        //
-                        if ($_SESSION['opc']->setTempShippingToBilling() === false) {
-                            return [
-                                'status' => 'reload',
-                                'errorMessage' => ERROR_OPC_ADDRESS_INVALID,
-                            ];
-                        }
-                    }
-                    $ship_to = 'billing';
-                // -----
-                // Otherwise, the order is to be shipped to a non-billing shipping address ...
-                //
-                } else {
-                    // -----
-                    // ... and the order's shipping address is currently set to its billing
-                    // address ...
-                    //
-                    if ($_SESSION['opc']->getShippingBilling() === true) {
-                        if (empty($_SESSION['sendto'])) {
-                            $_SESSION['sendto'] = $_SESSION['customer_default_address_id'];
-                        } else {
-                            $_SESSION['opc']->validateBilltoSendto('ship');
-                        }
-                        $_SESSION['shipping_billing'] = false;
-                    }
-                    $ship_to = 'shipping';
-                }
-            }
-
-            if (empty($_POST['payment'])) {
-                unset($_SESSION['payment']);
-            } else {
-                $_SESSION['payment'] = $_POST['payment'];
-            }
-
-            require DIR_WS_CLASSES . 'order.php';
-            $order = new order();
-
-            if (!isset($_POST['shipping'])) {
-                $module = '';
-                $method = '';
-                $_POST['shipping'] = '';
-            } else {
-                [$module, $method] = explode('_', $_POST['shipping']);
-            }
-
-            $free_shipping = $_SESSION['opc']->isOrderFreeShipping($_SESSION['sendto']);
-            $is_virtual_order = $_SESSION['opc']->isVirtualOrder();
-            $current_shipping = (isset($_SESSION['shipping'])) ? json_encode($_SESSION['shipping']) : 'shipping not set';
-
-            $checkout_one->debug_message(
-                "Shipping method change to $module ($method), sendto ($ship_to), free_shipping ($free_shipping), virtual order ($is_virtual_order). Current values: " .
-                $current_shipping . PHP_EOL . 
-                json_encode($order->info) . PHP_EOL .
-                json_encode($_POST),
-                true,
-                'zcAjaxOnePageCheckout'
-            );
-
-            if ($free_shipping === true || $is_virtual_order === true) {
-                $shipping_module_available = true;
-                $_SESSION['shipping'] = [
-                    'id' => 'free_free', 
-                    'title' => FREE_SHIPPING_TITLE, 
-                    'cost' => 0 
-                ];
-                $order->info['shipping_method'] = 'free_free';
-                if ($is_virtual_order === true) {
-                    $_SESSION['sendto'] = false;
-                } elseif ($_POST['shipping'] !== 'free_free') {
-                    $_POST['shipping'] = 'free_free';
-                    $checkout_one->debug_message('Modifying shipping method, (' . $_POST['shipping'] . ') submitted; free-shipping and virtual orders should be free_free.', false, 'zcAjaxOnePageCheckout');
-
-                    // -----
-                    // Re-render the shipping choices to show free shipping.
-                    //
-                    $this->disableGzip();
-                    $quotes = [];
-                    $quotes[0]['methods'][0]['title'] = FREE_SHIPPING_TITLE;
-                    $quotes[0]['methods'][0]['cost'] = '0';
-                    $quotes[0]['methods'][0]['icon'] = '';
-                    ob_start ();
-                    require $template->get_template_dir('tpl_modules_checkout_one_shipping.php', DIR_WS_TEMPLATE, $current_page_base, 'templates') . '/tpl_modules_checkout_one_shipping.php';
-                    $shipping_html = ob_get_clean();
-                }
-            } else {
-                // -----
-                // Got here if the previous address/cart qualified for 'free shipping' (as defined by ot_shipping), but
-                // a change has now invalidated that shipping method.  Perform some 'clean-up' so that a non-free
-                // shipping method will be used.
-                //
-                if (isset($_SESSION['shipping']) && $_SESSION['shipping'] === 'free_free') {
-                    unset($_SESSION['shipping']);
-                    $method = '';
-                    $module = '';
-                    $order->info['shipping_method'] = '';
-                }
-
-                if ($module !== '') {
-                    global ${$module};
-                }
-                require DIR_WS_CLASSES . 'shipping.php';
-                $shipping_modules = new shipping;
-            
-//-bof-product_delivery_by_postcode (PDP) integration
-                $is_localdelivery_enabled = false;
-                if (defined('MODULE_SHIPPING_LOCALDELIVERY_POSTCODE') && defined('MODULE_SHIPPING_STOREPICKUP_POSTCODE') && function_exists('zen_get_UKPostcodeFirstPart')) {
-                    global $localdelivery, $storepickup;
-
-                    $is_localdelivery_enabled = true;
-
-                    $check_delivery_postcode = $order->delivery['postcode'];
-
-                    // shorten UK / Canada postcodes to use first part only
-                    $check_delivery_postcode = zen_get_UKPostcodeFirstPart($check_delivery_postcode);
-
-                    // now check db for allowed postcodes and enable / disable relevant shipping modules
-                    if (!in_array($check_delivery_postcode, explode(',', MODULE_SHIPPING_LOCALDELIVERY_POSTCODE))) {
-                         $localdelivery = false;
-                    }
-
-                    if (!in_array($check_delivery_postcode, explode(',', MODULE_SHIPPING_STOREPICKUP_POSTCODE))) {
-                        $storepickup = false;
-                    }
-                }
-//-eof-product_delivery_by_postcode (PDP) integration
-    
-                $quote = $shipping_modules->quote($method, $module);
-                $session_shipping = (isset($_SESSION['shipping'])) ? json_encode($_SESSION['shipping']) : 'Shipping not set';
-                $checkout_one->debug_message("Current quote for " . $_POST['shipping'] . ": " . PHP_EOL . json_encode($quote) . PHP_EOL . $session_shipping);
-
-                if (!isset($quote[0]['methods'][0]['title']) || !isset($quote[0]['methods'][0]['cost'])) {
-                    $shipping_invalid = true;
-                } else {
-                    $shipping_cost = $quote[0]['methods'][0]['cost'];
-                    $shipping_title = $quote[0]['module'] . ' (' . $quote[0]['methods'][0]['title'] . ')';
-                    if (isset($_SESSION['shipping']) && $_SESSION['shipping']['id'] === $_POST['shipping'] && ($_SESSION['shipping']['title'] !== $shipping_title || $_SESSION['shipping']['cost'] != $shipping_cost)) {
-                        $shipping_invalid = true;
-                    } else {
-                        $shipping_invalid = false;
-                        $_SESSION['shipping'] = [
-                            'id' => $_POST['shipping'],
-                            'title' => $shipping_title,
-                            'cost' => $shipping_cost
-                        ];
-                        if (isset($quote[0]['extras'])) {
-                            $_SESSION['shipping']['extras'] = $quote[0]['extras'];
-                        }
-                    }
-                }
-
-                if ($shipping_invalid === true) {
-                    $checkout_one->debug_message('Shipping method returned empty result; no longer valid.');
-                    $error_message = ERROR_PLEASE_RESELECT_SHIPPING_METHOD;
-                    $status = 'invalid';
-                    unset($_SESSION['shipping']);
-                }
-                $order = new order();
-                $shipping_modules = new shipping(isset($_SESSION['shipping']) ? $_SESSION['shipping'] : '');
-
-//-bof-product_delivery_by_postcode (PDP) integration
-                if ($is_localdelivery_enabled === true) {
-                    global $localdelivery, $storepickup;
-
-                    $check_delivery_postcode = $order->delivery['postcode'];
-
-                    // shorten UK / Canada postcodes to use first part only
-                    $check_delivery_postcode = zen_get_UKPostcodeFirstPart($check_delivery_postcode);
-
-                    // now check db for allowed postcodes and enable / disable relevant shipping modules
-                    if (!in_array($check_delivery_postcode, explode(',', MODULE_SHIPPING_LOCALDELIVERY_POSTCODE))) {
-                         $localdelivery = false;
-                    }
-
-                    if (!in_array($check_delivery_postcode, explode(',', MODULE_SHIPPING_STOREPICKUP_POSTCODE))) {
-                        $storepickup = false;
-                    }
-                }
-//-eof-product_delivery_by_postcode (PDP) integration
-
-                $this->disableGzip();
-
-                $shipping_html = '';
-
-                if ($_POST['shipping_request'] === 'shipping-billing') {
-                    $quotes = $shipping_modules->quote();
-                    if (count($quotes) > 1 && count($quotes[0]) > 1) {
-                        $shipping_choose_message = TEXT_CHOOSE_SHIPPING_METHOD;
-                    } else {
-                        $shipping_choose_message = TEXT_ENTER_SHIPPING_INFORMATION;
-                    }
-                    $checkout_one->debug_message("Updating shipping section, message ($shipping_choose_message), quotes:" . json_encode($quotes), false, 'zcAjaxOnePageCheckout');
-
-                    if ((!isset($_SESSION['shipping']) || (!isset($_SESSION['shipping']['id']) || $_SESSION['shipping']['id'] === '') && zen_count_shipping_modules() >= 1)) {
-                        $_SESSION['shipping'] = $shipping_modules->cheapest();
-                    }
-
-                    ob_start ();
-                    require $template->get_template_dir('tpl_modules_checkout_one_shipping.php', DIR_WS_TEMPLATE, $current_page_base, 'templates') . '/tpl_modules_checkout_one_shipping.php';
-                    $shipping_html = ob_get_clean();
-                }
-
-                if ($status === 'ok' && isset($quote[0]['error'])) {
-                    $status = 'error';
-                    if (count($messageStack->messages) > 0) {
-                        foreach ($messageStack->messages as $current_message) {
-                            if ($current_message['class'] == 'checkout_shipping') {
-                                $error_message = strip_tags($current_message['text']);
-                                break;
-                            }
-                        }
-                        $messageStack->reset();
-                    }
-                }
-                unset($_SESSION['messageToStack']);
-
-                // -----
-                // Pull in, also, any changes to the shipping-methods available, given the change to shipping.
-                //
-                $shipping_module_available = ($free_shipping === true || $is_virtual_order === true || zen_count_shipping_modules() > 0);
-                $session_shipping = (isset($_SESSION['shipping'])) ? json_encode($_SESSION['shipping']) : 'Shipping not set';
-                $checkout_one->debug_message("Shipping method changed: " . json_encode($quote) . PHP_EOL . $session_shipping, false, 'zcAjaxOnePageCheckout');
-            }
-
-            $checkout_one->debug_message(
-                'Billing/shipping, exit (' . json_encode($_POST['shipping_is_billing']) . '), ' .
-                $_SESSION['sendto'] . ', ' .
-                $_SESSION['billto']  . ', (' .
-                $_SESSION['shipping_billing'] . ')',
-                false,
-                'zcAjaxOnePageCheckout::updateShipping'
-            );
-
-            // -----
-            // Pull in the payment-class processing at this point (was previously after the order-totals) to ensure
-            // that any order-total modules that are 'keyed to' a payment method are properly included.
-            //
-            if (!class_exists('payment')) {
-                require DIR_WS_CLASSES . 'payment.php';
-            }
-            $payment_modules = new payment();
-            $enabled_payment_modules = $_SESSION['opc']->validateGuestPaymentMethods($payment_modules->selection());
-            $display_payment_block = ($_SESSION['opc']->validateCustomerInfo() === true && $_SESSION['opc']->validateTempBilltoAddress() === true);
-            ob_start ();
-            require $template->get_template_dir('tpl_modules_opc_payment_choices.php', DIR_WS_TEMPLATE, $current_page_base, 'templates') . '/tpl_modules_opc_payment_choices.php';
-            $payment_html = ob_get_clean();
-
-            // -----
-            // Now, pull in any changes/re-calculations for the order's totals based on any shipping/payment
-            // processing.
-            //
-            if (!class_exists('order_total')) {
-                require DIR_WS_CLASSES . 'order_total.php';
-            }
-            $order_total_modules = new order_total;
-
-            ob_start();
-            $order_total_modules->process();
-            $_SESSION['opc_order_hash'] = md5(json_encode($order->info));
-            $order_total_modules->output();
-            $order_total_html = ob_get_clean();
+        $status = $this->initializeResponseStatus('setShippingEqualBilling', $error_message);
+        if ($status === 'ok' && $_SESSION['opc']->setShippingEqualBilling() === true) {
+            $status = 'reload';
         }
- 
-        $return_array = [
+
+        return [
             'status' => $status,
             'errorMessage' => $error_message,
-            'orderTotalHtml' => $order_total_html,
-            'shippingHtml' => $shipping_html,
-            'shippingMessage' => $shipping_choose_message,
-            'paymentHtml' => $payment_html,
         ];
-        $session_shipping = (isset($_SESSION['shipping'])) ? json_encode($_SESSION['shipping']) : 'Shipping not set';
-        $checkout_one->debug_message('updateShipping, returning:' . json_encode($return_array) . PHP_EOL . $session_shipping);
-
-        return $return_array;
     }
 
     // -----
@@ -678,11 +293,11 @@ class zcAjaxOnePageCheckout extends base
         //
         $status = $this->initializeResponseStatus('setAddressFromSavedSelections', $error_message);
         if ($status === 'ok') {
-            if (!isset($_POST['which']) || ($_POST['which'] !== 'bill' && $_POST['which'] !== 'ship')) {
+            if (!isset($_POST['which'], $_POST['address_id'], $_POST['shipping_is_billing']) || ($_POST['which'] !== 'bill' && $_POST['which'] !== 'ship')) {
                 $status = 'error';
                 $error_message = ERROR_INVALID_REQUEST;
             } else {
-                $_SESSION['opc']->setAddressFromSavedSelections($_POST['which'], $_POST['address_id']);
+                $_SESSION['opc']->setAddressFromSavedSelections($_POST['which'], (int)$_POST['address_id'], $_POST['shipping_is_billing']);
             }
         }
 
@@ -702,14 +317,6 @@ class zcAjaxOnePageCheckout extends base
     public function updatePaymentMethod()
     {
         // -----
-        // Since we're running as a function, need to declare the objects we're instantiating here, for use by the various classes
-        // involved in creating the order's total-block.
-        //
-        global $db, $order, $currencies, $checkout_one, $total_weight, $total_count, $discount_coupon, $messageStack;
-        global $shipping_weight, $uninsurable_value, $shipping_quoted, $shipping_num_boxes, $template, $template_dir;
-        global $language_page_directory, $shipping_modules, $payment_modules, $current_page_base;
-
-        // -----
         // Load the One-Page Checkout page's language files.
         //
         $this->loadLanguageFiles();
@@ -722,43 +329,83 @@ class zcAjaxOnePageCheckout extends base
         //
         $status = $this->initializeResponseStatus('updatePaymentMethod', $error_message);
         if ($status === 'ok') {
-            $this->disableGzip();
-
             if (empty($_POST['payment'])) {
                 unset($_SESSION['payment']);
             } else {
                 $_SESSION['payment'] = $_POST['payment'];
             }
 
-            require DIR_WS_CLASSES . 'order.php';
-            $order = new order();
-
-            require DIR_WS_CLASSES . 'shipping.php';
-            $shipping_modules = new shipping($_SESSION['shipping']);
-
-            require DIR_WS_CLASSES . 'payment.php';
-            $payment_modules = new payment();
-
-            if (!class_exists('order_total')) {
-                require DIR_WS_CLASSES . 'order_total.php';
-            }
-            $order_total_modules = new order_total();
-
-            ob_start();
-            $order_total_modules->process();
-            $_SESSION['opc_order_hash'] = md5(json_encode($order->info));
-            $order_total_modules->output();
-            $order_total_html = ob_get_clean();
+            $order_total_html = $this->createOrderTotalHtml();
         }
 
-        $return_array = [
+        return [
             'status' => $status,
             'errorMessage' => $error_message,
             'orderTotalHtml' => $order_total_html,
         ];
-        $checkout_one->debug_message('updateOrderTotals, returning:' . json_encode($return_array));
+    }
 
-        return $return_array;
+    protected function createOrderTotalHtml(): string
+    {
+        global $db, $order, $shipping_modules, $payment_modules, $checkout_one, $discount_coupon;
+
+        $this->disableGzip();
+
+        // -----
+        // Create an instance of the order-class, setting the in-cart products
+        // and their pricing/taxes as well as the updated shipping-selection recorded
+        // in the session, above.
+        //
+        require DIR_WS_CLASSES . 'order.php';
+        $order = new order();
+
+        // -----
+        // Create an instance of the shipping-class; that'll pull in the language files and make
+        // an instance of the currently-selected shipping modules.
+        //
+        require DIR_WS_CLASSES . 'shipping.php';
+        $shipping_modules = new shipping($_SESSION['shipping'] ?? null);
+
+        // -----
+        // Create an instance of the payment-class; that'll pull in the language file(s) and create
+        // an instance of the currently-selected payment module(s).
+        //
+        require DIR_WS_CLASSES . 'payment.php';
+        $payment_modules = new payment($_SESSION['payment'] ?? '');
+
+        // -----
+        // The ot_coupon order-total expects the $discount_coupon variable to be present if
+        // there's a coupon associated with the order.
+        //
+        if (!empty($_SESSION['cc_id'])) {
+            $discount_coupon_query = "SELECT coupon_code FROM " . TABLE_COUPONS . " WHERE coupon_id = :couponID LIMIT 1";
+            $discount_coupon_query = $db->bindVars($discount_coupon_query, ':couponID', $_SESSION['cc_id'], 'integer');
+            $discount_coupon = $db->Execute($discount_coupon_query);
+        }
+
+        // -----
+        // Pull in changes/re-calculations for the order's totals based on the change in
+        // shipping method.
+        //
+        require DIR_WS_CLASSES . 'order_total.php';
+        $order_total_modules = new order_total();
+
+        ob_start();
+        $order_total_modules->process();
+        $_SESSION['opc_order_hash'] = md5(json_encode($order->info));
+        $order_total_modules->output();
+        $order_total_html = ob_get_clean();
+
+        $checkout_one->debug_message(
+            "Returning:\n" .
+            json_encode($order->info, JSON_PRETTY_PRINT) . "\n" .
+            json_encode($_SESSION['shipping']) . "\n" .
+            ($_SESSION['payment'] ?? '[not set]'),
+            false,
+            'zcAjaxOnePageCheckout::createOrderTotalHtml'
+        );
+
+        return $order_total_html;
     }
 
     protected function renderAddressBlock($which)

--- a/includes/classes/observers/class.checkout_one_observer.php
+++ b/includes/classes/observers/class.checkout_one_observer.php
@@ -706,7 +706,9 @@ class checkout_one_observer extends base
                         unset($the_request[$name]);
                     }
                 }
-                $extra_info = print_r($the_request, true) . "\n\n" . print_r($_SESSION, true);
+                $session_vars = $_SESSION;
+                unset($session_vars['navigation']);
+                $extra_info = json_encode($the_request, JSON_PRETTY_PRINT) . "\n\n" . json_encode($session_vars, JSON_PRETTY_PRINT);
             }
 
             // -----

--- a/includes/languages/english/lang.checkout_one.php
+++ b/includes/languages/english/lang.checkout_one.php
@@ -1,9 +1,9 @@
 <?php
 // -----
 // Part of the One-Page Checkout plugin, provided under GPL 2.0 license by lat9.
-// Copyright (C) 2013-2023, Vinos de Frutas Tropicales.  All rights reserved.
+// Copyright (C) 2013-2024, Vinos de Frutas Tropicales.  All rights reserved.
 //
-// Last updated for OPC v2.4.6
+// Last updated for OPC v2.5.0
 //
 $define = [
     'NAVBAR_TITLE_1' => 'Checkout',
@@ -43,6 +43,8 @@ $define = [
     'ERROR_UNKNOWN_SHIPPING_SELECTION' => 'An unknown shipping-method was submitted.  Please contact the store owner.',
     'ERROR_INVALID_REQUEST' => 'An unknown request was received.  Please contact the store owner.',
 
+    'ERROR_AJAX_SHIPPING_SELECTION' => 'The shipping method you selected was not understood. Please contact the store owner.',
+
 // -----
 // These definitions are prepended to any address-value-related error message as an indication
 // of which address-field is being referenced.
@@ -61,8 +63,11 @@ $define = [
     'ERROR_OPC_ADDRESS_INVALID' => 'Sorry, we could not validate one or more of this order\'s addresses; please review and re-enter if necessary.',
 
 // -----
-// NOTE: The following constants are used in the page's jscript_main.php file as javascript text literals.  If you want to include single-quotes in a value,
-// you'll need to specify them as \\\'; for a new-line, use \n.  Just be sure to keep a constant's string within a set of single-quotes and you should be good-to-go!
+// NOTE: The following constants are used in the page's jscript_main.php file as javascript text literals or
+// for messages displayed to the customer during AJAX processing issues (displayed in a 'alert'.
+//
+// If you want to include single-quotes in a value, you'll need to specify them as \\\'; for a new-line,
+// use \n.  Just be sure to keep a constant's string within a set of single-quotes and you should be good-to-go!
 //
     'JS_ERROR_SESSION_TIMED_OUT' => 'Sorry, your session has timed out.\n\nThe items in your cart have been saved and will be restored the next time you log in.',
     'JS_ERROR_OPC_NOT_ENABLED' => 'Our expedited checkout process is temporarily unavailable.  You\\\'ll be redirected to our alternate checkout process.',

--- a/includes/modules/pages/checkout_one/header_php.php
+++ b/includes/modules/pages/checkout_one/header_php.php
@@ -203,7 +203,7 @@ if ($is_virtual_order === false && $customer_info_ok === true && $temp_shipto_ad
     }
 //-eof-product_delivery_by_postcode (PDP) integration
 
-    $extra_message = (isset($_SESSION['shipping'])) ? var_export($_SESSION['shipping'], true) : ' (not set)';
+    $extra_message = json_encode(($_SESSION['shipping'] ?? ' (not set)'), JSON_PRETTY_PRINT);
 
     // -----
     // Detect (and log) the condition where the store's configuration shows "Shipping/Packaging->Order Free Shipping 0 Weight Status"
@@ -220,7 +220,7 @@ if ($is_virtual_order === false && $customer_info_ok === true && $temp_shipto_ad
     $quotes = $shipping_modules->quote();
 
     // -----
-    // If a shipping-method was previously selected, check that it is still valid (in case a zone restriction has disabled it, etc). 
+    // If a shipping-method was previously selected, check that it is still valid (in case a zone restriction has disabled it, etc).
     //
     // Also take this opportunity to see if the selected module's cost has changed.  If it has, just update the current method's
     // price for the display.
@@ -233,6 +233,10 @@ if ($is_virtual_order === false && $customer_info_ok === true && $temp_shipto_ad
             if (!empty($quote['methods'])) {
                 foreach ($quote['methods'] as $method) {
                     if ($_SESSION['shipping']['id'] === $quote['id'] . '_' . $method['id']) {
+                        // -----
+                        // Using a 'loose' comparison, since some costs are recorded as numbers
+                        // and some as strings.
+                        //
                         if ($_SESSION['shipping']['cost'] == $method['cost']) {
                             $checklist[] = $quote['id'] . '_' . $method['id'];
                         }
@@ -244,7 +248,12 @@ if ($is_virtual_order === false && $customer_info_ok === true && $temp_shipto_ad
         }
 
         $checkval = $_SESSION['shipping']['id'];
-        $checkout_one->debug_message("CHECKOUT_ONE_SHIPPING_CHECK ($checkval)\n" . json_encode($quotes, JSON_PRETTY_PRINT) . "\n" . json_encode($checklist, JSON_PRETTY_PRINT));
+        $checkout_one->debug_message(
+            "CHECKOUT_ONE_SHIPPING_CHECK\n" .
+            json_encode($_SESSION['shipping'], JSON_PRETTY_PRINT) . "\n" .
+            json_encode($quotes, JSON_PRETTY_PRINT) . "\n" .
+            json_encode($checklist, JSON_PRETTY_PRINT)
+        );
         if (!in_array($checkval, $checklist) && !($_SESSION['shipping']['id'] === 'free_free' && ($is_virtual_order === true || $free_shipping === true))) {
             // -----
             // Since the available shipping methods have changed, need to kill the current shipping method and display a

--- a/includes/modules/pages/checkout_one/jquery.checkout_one.js
+++ b/includes/modules/pages/checkout_one/jquery.checkout_one.js
@@ -516,21 +516,19 @@ jQuery(document).ready(function(){
                         }
                     }
                     if (response.errorMessage != '') {
-                        if (type == 'submit' || (type == 'shipping-billing' && response.status != 'invalid') || type == 'submit-cc') {
+                        if (type == 'submit' || (type == 'shipping-billing' && response.status != 'invalid')) {
                             alert(response.errorMessage);
                         }
                     }
                 }  
                 zcLog2Console('Shipping method updated, error: '+shippingError); 
 
-                if (response.status !== 'reload' && (type === 'submit' || type === 'submit-cc')) {
+                if (response.status !== 'reload' && type === 'submit') {
                     if (shippingError == true) {
                         zcLog2Console('Shipping error, correct to proceed.');
                     } else {
                         zcLog2Console('Form submitted, type ('+type+'), submit_type('+submit_type+'), orderConfirmed ('+orderConfirmed+')');
-                        if (type == 'submit-cc') {
-                            jQuery('form[name="checkout_payment"]').submit();
-                        } else if (orderConfirmed) {
+                        if (orderConfirmed) {
                             jQuery('#confirm-the-order').attr('disabled', true);
 
                             // -----
@@ -591,14 +589,13 @@ jQuery(document).ready(function(){
     // -----
     // The tpl_checkout_one_default.php processing has applied 'class="opc-cc-submit"' to each credit-class
     // order-total's "Apply" button.  When one of those "Apply" buttons is clicked, note that the order has
-    // **not** been confirmed, make the AJAX call to recalculate the order-totals and submit the form,
-    // causing the transition to (and back from) the checkout_one_confirmation page where that credit-class
-    // processing has recorded its changes.
+    // **not** been confirmed and the transition to (and back from) the checkout_one_confirmation page
+    // where that credit-class processing will record its changes.
     //
     jQuery(document).on('click', '.opc-cc-submit', function(event) {
         zcLog2Console('Submitting credit-class request');
         setOrderConfirmed(0);
-        changeShippingSubmitForm('submit-cc');
+        jQuery('form[name="checkout_payment"]').submit();
     });
 
     // -----

--- a/includes/modules/pages/checkout_one/jquery.checkout_one.js
+++ b/includes/modules/pages/checkout_one/jquery.checkout_one.js
@@ -12,7 +12,7 @@ var submitter = null;
 //
 function concatExpiresFields(fields) 
 {
-    return jQuery(":input[name=" + fields[0] + "]").val() + jQuery(":input[name=" + fields[1] + "]").val();
+    return jQuery(':input[name='+fields[0]+']').val()+ jQuery(':input[name='+ fields[1]+']').val();
 }
 
 function popupWindow(url) 
@@ -31,16 +31,16 @@ function couponpopupWindow(url)
 //
 function submitonce()
 {
-    var button = document.getElementById("btn_submit");
-    button.style.cursor = "wait";
+    var button = document.getElementById('btn_submit');
+    button.style.cursor = 'wait';
     button.disabled = true;
     setTimeout('button_timeout()', shippingTimeout);
     return false;
 }
 function button_timeout() 
 {
-    var button = document.getElementById("btn_submit");
-    button.style.cursor = "pointer";
+    var button = document.getElementById('btn_submit');
+    button.style.cursor = 'pointer';
     button.disabled = false;
 }
 
@@ -73,7 +73,7 @@ function methodSelect(theMethod)
 //
 function setJavaScriptEnabled()
 {
-    var jsEnabled = document.getElementById( 'javascript-enabled' );
+    var jsEnabled = document.getElementById('javascript-enabled');
     if (jsEnabled) {
         jsEnabled.value = '1';
     }
@@ -101,13 +101,13 @@ jQuery(document).ready(function() {
     // are missing.
     //
     var elementsMissing = false;
-    if (jQuery( 'form[name="checkout_payment"]' ).length == 0) {
+    if (jQuery('form[name="checkout_payment"]').length == 0) {
         elementsMissing = true;
-        zcLog2Console( 'Missing form[name="checkout_payment"]' );
+        zcLog2Console('Missing form[name="checkout_payment"]');
     }
-    if (jQuery( '#orderTotalDivs' ).length == 0) {
+    if (jQuery('#orderTotalDivs').length == 0) {
         elementsMissing = true;
-        zcLog2Console( 'Missing #orderTotalDivs' );
+        zcLog2Console('Missing #orderTotalDivs');
     }
 
     // -----
@@ -170,7 +170,7 @@ jQuery(document).ready(function() {
     // Requires:
     // - checkbox, id="shipping_billing"
     //
-    function shippingIsBilling() 
+    function shippingIsBilling()
     {
         if (jQuery('#checkoutOneShipto').length) {
             if (jQuery("#shipping_billing").is(':checked')) {
@@ -194,7 +194,7 @@ jQuery(document).ready(function() {
     // Disallow the Enter key (so that all form-submittal actions occur via "click"), except when that
     // key is pressed within a textarea section.
     //
-    jQuery(document).on("keypress", ":input:not(textarea)", function(event) {
+    jQuery(document).on('keypress', ':input:not(textarea)', function(event) {
         return event.keyCode != 13;
     });
 
@@ -213,7 +213,7 @@ jQuery(document).ready(function() {
         var payment_module = null;
         if (document.checkout_payment.payment) {
             if (document.checkout_payment.payment.length) {
-                for (var i=0; i<document.checkout_payment.payment.length; i++) {
+                for (var i = 0; i < document.checkout_payment.payment.length; i++) {
                     if (document.checkout_payment.payment[i].checked) {
                         payment_module = document.checkout_payment.payment[i].value;
                     }
@@ -224,10 +224,10 @@ jQuery(document).ready(function() {
                 payment_module = document.checkout_payment.payment.value;
             }
         }
-        zcLog2Console( 'setFormSubmitButton, payment-module: '+payment_module );
+        zcLog2Console('setFormSubmitButton, payment-module: '+payment_module);
         jQuery( '#opc-order-review, #opc-order-confirm' ).hide();
         if (payment_module == null || confirmation_required.indexOf(payment_module) == -1) {
-            jQuery( '#opc-order-confirm' ).show();
+            jQuery('#opc-order-confirm').show();
             if (payment_module != null && paymentsThatSubmit.indexOf(payment_module) != -1) {
                 paymentMethodHandlesSubmit = true;
             } else {
@@ -235,7 +235,7 @@ jQuery(document).ready(function() {
             }
             zcLog2Console('Showing "confirm", paymentMethodHandlesSubmit ('+paymentMethodHandlesSubmit+')');
         } else {
-            jQuery( '#opc-order-review' ).show();
+            jQuery('#opc-order-review').show();
             zcLog2Console( 'Showing "review"' );
         }
         if ((jQuery('#privacy').length != 0 && !jQuery('#privacy').is(':checked')) || (jQuery('#conditions').length != 0 && !jQuery('#conditions').is(':checked'))) {
@@ -312,15 +312,15 @@ jQuery(document).ready(function() {
 
     doesCollectsCardDataOnsite = function(paymentValue)
     {
-        zcLog2Console( 'Checking doesCollectsCardDataOnsite('+paymentValue+') ...' );
+        zcLog2Console('Checking doesCollectsCardDataOnsite('+paymentValue+') ...');
         if (jQuery('#'+paymentValue+'_collects_onsite').val()) {
             if (jQuery('#pmt-'+paymentValue).is(':checked')) {
-                zcLog2Console( '... it does!' );
+                zcLog2Console('... it does!');
                 lastPaymentValue = paymentValue;
                 return true;
             }
         }
-        zcLog2Console( '... it does not.' );
+        zcLog2Console('... it does not.');
         lastPaymentValue = null;
         return false;
     }
@@ -329,11 +329,11 @@ jQuery(document).ready(function() {
     {
         var str = jQuery('form[name="checkout_payment"]').serializeArray();
 
-        zcLog2Console( 'doCollectsCardDataOnsite for '+lastPaymentValue );
+        zcLog2Console('doCollectsCardDataOnsite for '+lastPaymentValue);
         zcJS.ajax({
-            url: "ajax.php?act=ajaxPayment&method=prepareConfirmation",
+            url: 'ajax.php?act=ajaxPayment&method=prepareConfirmation',
             data: str
-        }).done(function( response ) {
+        }).done(function(response) {
             // -----
             // On return from a successful AJAX request, the updated HTML includes some
             // 'jQuery(document).ready(function()' processing to be performed, but the document's
@@ -341,12 +341,12 @@ jQuery(document).ready(function() {
             // jQuery to do its thing.
             //
             jQuery('#checkoutPayment').hide();
-            jQuery('#navBreadCrumb').html(response.breadCrumbHtml.replace(/\.ready/g, ".ajaxComplete"));
-            jQuery('#checkoutPayment').before(response.confirmationHtml.replace(/\.ready/g, ".ajaxComplete"));
+            jQuery('#navBreadCrumb').html(response.breadCrumbHtml.replace(/\.ready/g, '.ajaxComplete'));
+            jQuery('#checkoutPayment').before(response.confirmationHtml.replace(/\.ready/g, '.ajaxComplete'));
             jQuery(document).attr('title', response.pageTitle);
             jQuery(document).scrollTop( 0 );
             if (confirmation_required.indexOf( lastPaymentValue ) == -1) {
-                zcLog2Console( 'Preparing to submit form, since confirmation is not required for "'+lastPaymentValue+'", per the required list: "'+confirmation_required );
+                zcLog2Console('Preparing to submit form, since confirmation is not required for "'+lastPaymentValue+'", per the required list: "'+confirmation_required);
                 jQuery('#checkoutOneLoading').show();
                 jQuery('#checkoutConfirmationDefault').hide();
                 
@@ -358,7 +358,7 @@ jQuery(document).ready(function() {
                     jQuery('form[name="checkout_confirmation"]')[0].submit();
                 });
             } else {
-                zcLog2Console( 'Confirmation required, displaying for '+lastPaymentValue+'.' );
+                zcLog2Console('Confirmation required, displaying for '+lastPaymentValue+'.');
                 jQuery('#checkoutConfirmDefault').show();
             }
         });
@@ -416,7 +416,7 @@ jQuery(document).ready(function() {
             submit_type = ''; 
         }
         var shippingSelected = jQuery('input[name=shipping]');
-        if (shippingSelected.is( ':radio' )) {
+        if (shippingSelected.is(':radio')) {
             shippingSelected = jQuery('input[name=shipping]:checked');
         }
         if (shippingSelected.length == 0 && type != 'shipping-billing') {
@@ -424,7 +424,7 @@ jQuery(document).ready(function() {
             focusOnShipping();
         } else {
             shippingSelected = shippingSelected.val();
-            var shippingIsBilling = jQuery( '#shipping_billing' ).is( ':checked' );
+            var shippingIsBilling = jQuery('#shipping_billing').is(':checked');
             var paymentSelected = jQuery('input[name=payment]');
             if (paymentSelected.is(':radio')) {
                 paymentSelected = jQuery('input[name=payment]:checked');
@@ -451,7 +451,7 @@ jQuery(document).ready(function() {
 
             zcLog2Console('Updating shipping method to '+shippingSelected+', processing type: '+type);
             zcJS.ajax({
-                url: "ajax.php?act=ajaxOnePageCheckout&method=updateShipping",
+                url: 'ajax.php?act=ajaxOnePageCheckout&method=updateShipping',
                 data: shippingData,
                 timeout: shippingTimeout,
                 error: function (jqXHR, textStatus, errorThrown) {
@@ -468,24 +468,6 @@ jQuery(document).ready(function() {
                 checkForRedirect(response);
 
                 jQuery('#orderTotalDivs').html(response.orderTotalHtml);
-
-                // -----
-                // Don't change the payment-method block if a form-submittal is requested.  Otherwise, the
-                // customer's just-entered credit-card credentials will be "wiped out".
-                //
-                // The same is true for stores that use payment methods that don't "tolerate"
-                // a page-refresh.
-                //
-                if (type != 'submit') {
-                    if (response.paymentHtmlAction == 'refresh') {
-                        window.location.reload(true);
-                    } else if (response.paymentHtmlAction == 'update') {
-                        jQuery('#checkoutPaymentMethod').replaceWith(response.paymentHtml);
-                        jQuery(document).on('change', 'input[name=payment]', function() {
-                            setFormSubmitButton();
-                        });
-                    }
-                }
 
                 var shippingError = false;
                 jQuery('#otshipping, #otshipping+br').show();
@@ -658,7 +640,7 @@ jQuery(document).ready(function() {
 
         zcLog2Console('Updating payment method to '+paymentSelected);
         zcJS.ajax({
-            url: "ajax.php?act=ajaxOnePageCheckout&method=updatePaymentMethod",
+            url: 'ajax.php?act=ajaxOnePageCheckout&method=updatePaymentMethod',
             data: paymentData,
             timeout: shippingTimeout,
             error: function (jqXHR, textStatus, errorThrown) {
@@ -682,8 +664,8 @@ jQuery(document).ready(function() {
     // to submit their order.  Set up the various "hidden" fields to reflect the order's current state,
     // note that this is an order-review request, and cause the order to be submitted.
     //
-    jQuery(document).on('click', '#opc-order-review', function(event) {
-        submitFunction(0,0); 
+    jQuery(document).on('click', '#opc-order-review', function() {
+        submitFunction(0,0);
         setOrderConfirmed(1);
 
         zcLog2Console('Submitting order-creating form (review)');
@@ -695,7 +677,7 @@ jQuery(document).ready(function() {
     // to submit their order.  Set up the various "hidden" fields to reflect the order's current state,
     // note that this is an order-confirmation request, and cause the order to be submitted.
     //
-    jQuery(document).on('click', '#opc-order-confirm', function(event) {
+    jQuery(document).on('click', '#opc-order-confirm', function() {
         submitFunction(0,0); 
         setOrderConfirmed(1);
 
@@ -706,10 +688,10 @@ jQuery(document).ready(function() {
     // -----
     // Monitor the billing- and shipping-address blocks for changes.
     //
-    jQuery(document).on('change', '#select-address-bill', function(event) {
+    jQuery(document).on('change', '#select-address-bill', function() {
         useSelectedAddress('bill', this.value);
     });
-    jQuery(document).on('change', '#select-address-ship', function(event) {
+    jQuery(document).on('change', '#select-address-ship', function() {
         useSelectedAddress('ship', this.value);
     });
     function useSelectedAddress(which, address_id)
@@ -717,7 +699,7 @@ jQuery(document).ready(function() {
         zcLog2Console('useSelectedAddress('+which+', '+address_id+')');
         jQuery('#checkoutPayment > .opc-overlay').addClass('active');
         zcJS.ajax({
-            url: "ajax.php?act=ajaxOnePageCheckout&method=setAddressFromSavedSelections",
+            url: 'ajax.php?act=ajaxOnePageCheckout&method=setAddressFromSavedSelections',
             data: {
                 which: which,
                 address_id: address_id
@@ -729,7 +711,7 @@ jQuery(document).ready(function() {
                     alert(ajaxTimeoutSetAddressErrorMessage);
                 }
             },
-        }).done(function( response ) {
+        }).done(function(response) {
             location.reload();
         });
     }
@@ -818,7 +800,7 @@ jQuery(document).ready(function() {
     {
         zcLog2Console('restoreAddressValues('+which+', '+address_block+')');
         zcJS.ajax({
-            url: "ajax.php?act=ajaxOnePageCheckout&method=restoreAddressValues",
+            url: 'ajax.php?act=ajaxOnePageCheckout&method=restoreAddressValues',
             data: {
                 which: which
             },
@@ -869,7 +851,7 @@ jQuery(document).ready(function() {
             add_address = jQuery('#opc-add-'+which).prop('checked');
 
         zcJS.ajax({
-            url: "ajax.php?act=ajaxOnePageCheckout&method=validateAddressValues",
+            url: 'ajax.php?act=ajaxOnePageCheckout&method=validateAddressValues',
             data: {
                 which: which,
                 gender: gender,
@@ -984,7 +966,7 @@ jQuery(document).ready(function() {
     {
         zcLog2Console('restoreCustomerInfo, starts ...');
         zcJS.ajax({
-            url: "ajax.php?act=ajaxOnePageCheckout&method=restoreCustomerInfo",
+            url: 'ajax.php?act=ajaxOnePageCheckout&method=restoreCustomerInfo',
             timeout: shippingTimeout,
             error: function (jqXHR, textStatus, errorThrown) {
                 zcLog2Console('error: status='+textStatus+', errorThrown = '+errorThrown+', override: '+jqXHR);
@@ -1007,7 +989,7 @@ jQuery(document).ready(function() {
     {
         zcLog2Console('saveCustomerInfo, starts ...');
         zcJS.ajax({
-            url: "ajax.php?act=ajaxOnePageCheckout&method=validateCustomerInfo",
+            url: 'ajax.php?act=ajaxOnePageCheckout&method=validateCustomerInfo',
             data: jQuery('#checkoutOneGuestInfo input, #checkoutOneGuestInfo select').serialize(),
             timeout: shippingTimeout,
             error: function (jqXHR, textStatus, errorThrown) {

--- a/includes/modules/pages/checkout_one/jquery.checkout_one.js
+++ b/includes/modules/pages/checkout_one/jquery.checkout_one.js
@@ -308,52 +308,6 @@ jQuery(document).ready(function(){
         zcLog2Console('submitFunction, on exit submitter='+submitter);
     }
 
-    // -----
-    // The "collectsCartDataOnsite" interface built into Zen Cart magically transformed between
-    // Zen Cart 1.5.4 and 1.5.5, so this module for the One-Page Checkout plugin includes both
-    // forms.  That way, if a payment module was written for 1.5.4 it'll work, ditto for those
-    // written for the 1.5.5 method.
-    //
-    // Zen Cart 1.5.4 uses the single-function approach (collectsCardDataOnsite) while the 1.5.5
-    // approach splits the functions int "doesCollectsCardDataOnsite" and "doCollectsCardDataOnsite".
-    //
-    collectsCardDataOnsite = function(paymentValue)
-    {
-        zcLog2Console( 'Checking collectsCardDataOnsite('+paymentValue+') ...' );
-        zcJS.ajax({
-            url: "ajax.php?act=ajaxPayment&method=doesCollectsCardDataOnsite",
-            data: {paymentValue: paymentValue}
-        }).done(function( response ) {
-            if (response.data == true) {
-                zcLog2Console( ' ... it does!' );
-                var str = jQuery('form[name="checkout_payment"]').serializeArray();
-
-                zcJS.ajax({
-                    url: "ajax.php?act=ajaxPayment&method=prepareConfirmation",
-                    data: str
-                }).done(function( response ) {
-                    jQuery('#checkoutPayment').hide();
-                    jQuery('#navBreadCrumb').html(response.breadCrumbHtml);
-                    jQuery('#checkoutPayment').before(response.confirmationHtml);
-                    jQuery(document).attr('title', response.pageTitle);
-                    jQuery(document).scrollTop( 0 );
-                    if (confirmation_required.indexOf( paymentValue ) == -1) {
-                        zcLog2Console( 'Preparing to submit form, since confirmation is not required for "'+paymentValue+'", per the required list: "'+confirmation_required );
-                        jQuery('#checkoutOneLoading').show();
-                        jQuery('form[name="checkout_confirmation"]')[0].submit();
-                    } else {
-                        zcLog2Console( 'Confirmation required, displaying for '+paymentValue+'.' );
-                        jQuery('#checkoutConfirmDefault').show();
-                    }
-                });
-            } else {
-                zcLog2Console( ' ... it does not, submitting.' );
-                jQuery('form[name="checkout_payment"]')[0].submit();
-            }
-        });
-        return false;
-    }
-
     var lastPaymentValue = null;
 
     doesCollectsCardDataOnsite = function(paymentValue)

--- a/includes/modules/pages/checkout_one/jscript_main.php
+++ b/includes/modules/pages/checkout_one/jscript_main.php
@@ -1,7 +1,9 @@
 <?php
 // -----
 // Part of the One-Page Checkout plugin, provided under GPL 2.0 license by lat9
-// Copyright (C) 2013-2022, Vinos de Frutas Tropicales.  All rights reserved.
+// Copyright (C) 2013-2024, Vinos de Frutas Tropicales.  All rights reserved.
+//
+// Last updated: OPC v2.5.0
 //
 ?>
 <script>
@@ -37,67 +39,81 @@ if (CHECKOUT_ONE_PAYMENT_METHODS_THAT_SUBMIT !== '') {
 //
 $show_state_dropdowns = true;
 ?>
-var confirmation_required = [<?php echo $required_list; ?>];
-var paymentsThatSubmit = [<?php echo $payments_that_submit; ?>];
+    var confirmation_required = [<?= $required_list ?>];
+    var paymentsThatSubmit = [<?= $payments_that_submit ?>];
 
-var virtual_order = <?php echo ($is_virtual_order) ? 'true' : 'false'; ?>;
-var timeoutUrl = '<?php echo zen_href_link(FILENAME_LOGIN, '', 'SSL'); ?>';
-var sessionTimeoutErrorMessage = '<?php echo JS_ERROR_SESSION_TIMED_OUT; ?>';
-var ajaxTimeoutErrorMessage = '<?php echo JS_ERROR_AJAX_TIMEOUT . JS_ERROR_CONTACT_US; ?>';
-var ajaxTimeoutShippingErrorMessage = '<?php echo JS_ERROR_AJAX_SHIPPING_TIMEOUT . JS_ERROR_CONTACT_US; ?>';
-var ajaxTimeoutPaymentErrorMessage = '<?php echo JS_ERROR_AJAX_PAYMENT_TIMEOUT . JS_ERROR_CONTACT_US; ?>';
-var ajaxTimeoutSetAddressErrorMessage = '<?php echo JS_ERROR_AJAX_SET_ADDRESS_TIMEOUT . JS_ERROR_CONTACT_US; ?>';
-var ajaxTimeoutRestoreAddressErrorMessage = '<?php echo JS_ERROR_AJAX_RESTORE_ADDRESS_TIMEOUT . JS_ERROR_CONTACT_US; ?>';
-var ajaxTimeoutValidateAddressErrorMessage = '<?php echo JS_ERROR_AJAX_VALIDATE_ADDRESS_TIMEOUT . JS_ERROR_CONTACT_US; ?>';
-var ajaxTimeoutRestoreCustomerErrorMessage = '<?php echo JS_ERROR_AJAX_RESTORE_CUSTOMER_TIMEOUT . JS_ERROR_CONTACT_US; ?>';
-var ajaxTimeoutValidateCustomerErrorMessage = '<?php echo JS_ERROR_AJAX_VALIDATE_CUSTOMER_TIMEOUT . JS_ERROR_CONTACT_US; ?>';
-var ajaxNotAvailableMessage = '<?php echo JS_ERROR_OPC_NOT_ENABLED; ?>';
-var checkoutShippingUrl = '<?php echo zen_href_link(FILENAME_CHECKOUT_SHIPPING, '', 'SSL'); ?>';
-var noShippingSelectedError = '<?php echo ERROR_NO_SHIPPING_SELECTED; ?>';
-var flagOnSubmit = <?php echo ($flagOnSubmit) ? 'true' : 'false'; ?>;
-var shippingTimeout = <?php echo (int)((defined('CHECKOUT_ONE_SHIPPING_TIMEOUT')) ? CHECKOUT_ONE_SHIPPING_TIMEOUT : 5000); ?>;
-var textPleaseSelect = '<?php echo PLEASE_SELECT; ?>';
-var displayShippingBlock = <?php echo ($display_shipping_block) ? 'true' : 'false'; ?>;
-var displayPaymentBlock = <?php echo ($display_payment_block) ? 'true' : 'false'; ?>;
-var ottotalSelector = '<?php echo CHECKOUT_ONE_OTTOTAL_SELECTOR; ?>';
-var billingTitle = '<?php echo TITLE_BILLING_ADDRESS; ?>';
-var billingShippingTitle = '<?php echo TITLE_BILLING_SHIPPING_ADDRESS; ?>';
-var shippingChoiceAvailable = <?php echo (is_array($quotes) && count($quotes) > 0) ? 'true' : 'false'; ?>;
-var paymentChoiceAvailable = <?php echo (is_array($enabled_payment_modules) && count($enabled_payment_modules) > 0) ? 'true' : 'false'; ?>;
+    var virtual_order = <?= ($is_virtual_order) ? 'true' : 'false' ?>;
+    var timeoutUrl = '<?= zen_href_link(FILENAME_LOGIN, '', 'SSL') ?>';
+    var sessionTimeoutErrorMessage = '<?= JS_ERROR_SESSION_TIMED_OUT ?>';
+    var ajaxTimeoutErrorMessage = '<?= JS_ERROR_AJAX_TIMEOUT . JS_ERROR_CONTACT_US ?>';
+    var ajaxTimeoutShippingErrorMessage = '<?= JS_ERROR_AJAX_SHIPPING_TIMEOUT . JS_ERROR_CONTACT_US ?>';
+    var ajaxTimeoutPaymentErrorMessage = '<?= JS_ERROR_AJAX_PAYMENT_TIMEOUT . JS_ERROR_CONTACT_US ?>';
+    var ajaxTimeoutSetAddressErrorMessage = '<?= JS_ERROR_AJAX_SET_ADDRESS_TIMEOUT . JS_ERROR_CONTACT_US ?>';
+    var ajaxTimeoutRestoreAddressErrorMessage = '<?= JS_ERROR_AJAX_RESTORE_ADDRESS_TIMEOUT . JS_ERROR_CONTACT_US ?>';
+    var ajaxTimeoutValidateAddressErrorMessage = '<?= JS_ERROR_AJAX_VALIDATE_ADDRESS_TIMEOUT . JS_ERROR_CONTACT_US ?>';
+    var ajaxTimeoutRestoreCustomerErrorMessage = '<?= JS_ERROR_AJAX_RESTORE_CUSTOMER_TIMEOUT . JS_ERROR_CONTACT_US ?>';
+    var ajaxTimeoutValidateCustomerErrorMessage = '<?= JS_ERROR_AJAX_VALIDATE_CUSTOMER_TIMEOUT . JS_ERROR_CONTACT_US ?>';
+    var ajaxNotAvailableMessage = '<?= JS_ERROR_OPC_NOT_ENABLED ?>';
+    var checkoutShippingUrl = '<?= zen_href_link(FILENAME_CHECKOUT_SHIPPING, '', 'SSL') ?>';
+    var noShippingSelectedError = '<?= ERROR_NO_SHIPPING_SELECTED ?>';
+    var flagOnSubmit = <?= ($flagOnSubmit) ? 'true' : 'false' ?>;
+    var shippingTimeout = <?= (int)((defined('CHECKOUT_ONE_SHIPPING_TIMEOUT')) ? CHECKOUT_ONE_SHIPPING_TIMEOUT : 5000) ?>;
+    var textPleaseSelect = '<?= PLEASE_SELECT ?>';
+    var displayShippingBlock = <?= ($display_shipping_block) ? 'true' : 'false' ?>;
+    var displayPaymentBlock = <?= ($display_payment_block) ? 'true' : 'false' ?>;
+    var ottotalSelector = '<?= CHECKOUT_ONE_OTTOTAL_SELECTOR ?>';
+    var billingTitle = '<?= TITLE_BILLING_ADDRESS ?>';
+    var billingShippingTitle = '<?= TITLE_BILLING_SHIPPING_ADDRESS ?>';
+    var shippingChoiceAvailable = <?= (is_array($quotes) && count($quotes) > 0) ? 'true' : 'false' ?>;
+    var paymentChoiceAvailable = <?= (is_array($enabled_payment_modules) && count($enabled_payment_modules) > 0) ? 'true' : 'false' ?>;
 <?php
 // -----
 // If dropdown states are to be displayed, include that json-formatted array of countries/zones.
 //
-if ($show_state_dropdowns) {
+if ($show_state_dropdowns === true) {
     echo $_SESSION['opc']->getCountriesZonesJavascript();
 }
-?>
-var additionalShippingInputs = {
-<?php
+
 // -----
-// If the current order has generated shipping quotes (i.e. it's got at least one physical product), check to see if a 
-// shipping-module has required inputs that should accompany the post, format the necessary jQuery to gather those inputs.
+// Save the shipping quotes' information into the session, for use by the AJAX
+// processing's 'updateShippingSelection' method.
 //
-$input_array = 'var shippingInputs = {';
+// Keeping the values in the session so that the checkout_one page's
+// jquery.checkout_one.js can simply pass the updated shipping-method "name". Otherwise,
+// characters like &nbsp; and &reg; get decoded to their utf8 representation and
+// make it "difficult" to record those values in the order.
+//
+$_SESSION['opc_shipping_quotes'] = [];
+$opc_additional_shipping_inputs = [];
 if (isset($quotes) && is_array($quotes)) {
-    $additional_shipping_inputs = [];
     foreach ($quotes as $current_quote) {
+        if (empty($current_quote['methods'])) {
+            continue;
+        }
+
+        $module_id = $current_quote['id'];
+        $_SESSION['opc_shipping_quotes'][$module_id] = [
+            'title' => $current_quote['module'],
+        ];
+        foreach ($current_quote['methods'] as $next_method) {
+            $_SESSION['opc_shipping_quotes'][$module_id][$next_method['id']] = [
+                'title' => $next_method['title'],
+                'cost' => $next_method['cost'],
+            ];
+        }
+
         if (isset($current_quote['required_input_names']) && is_array($current_quote['required_input_names'])) {
             foreach ($current_quote['required_input_names'] as $current_input_name => $selection_required) {
-                $variable_name = base::camelize($current_input_name);
-                $input_array .= "$variable_name: '', ";
-?>
-    <?php echo $variable_name; ?>: { input_name: '<?php echo $current_input_name; ?>', parms: '<?php echo ($selection_required) ? ':checked' : ''; ?>' },
-<?php
+                $opc_additional_shipping_inputs[base::camelize($current_input_name)] = [
+                    'input_name' => '',
+                    'parms' => ($selection_required) ? ':checked' : '',
+                ];
             }
         }
     }
 }
 ?>
-};
-<?php
-echo $input_array . '};'.PHP_EOL;
-?>
+    var additionalShippingInputs = <?= json_encode($opc_additional_shipping_inputs) ?>;
 </script>
 <?php
 if (defined('CHECKOUT_ONE_MINIFIED_SCRIPT') && CHECKOUT_ONE_MINIFIED_SCRIPT === 'true') {
@@ -111,17 +127,17 @@ $main_script_filepath = DIR_WS_MODULES . "pages/checkout_one/$main_script_filena
 $main_script_mtime = filemtime($main_script_filepath);
 $main_script_filepath .= "?$main_script_mtime";
 ?>
-<script src="<?php echo $main_script_filepath; ?>" defer></script>
+<script src="<?= $main_script_filepath ?>" defer></script>
 <?php
 // -----
 // Check to see if dropdown states are to be displayed, including that processing only
 // if enabled.
 //
-if ($show_state_dropdowns) {
+if ($show_state_dropdowns === true) {
     $addr_script_filepath = DIR_WS_MODULES . "pages/checkout_one/$addr_script_filename";
     $addr_script_mtime = filemtime($addr_script_filepath);
     $addr_script_filepath .= "?$addr_script_mtime";
 ?>
-<script src="<?php echo $addr_script_filepath; ?>" defer></script>
+<script src="<?= $addr_script_filepath ?>" defer></script>
 <?php
 }

--- a/includes/modules/pages/checkout_one_confirmation/header_php.php
+++ b/includes/modules/pages/checkout_one_confirmation/header_php.php
@@ -94,13 +94,6 @@ if (isset($_SESSION['shipping']['id']) && $_SESSION['shipping']['id'] === 'free_
 //
 if (isset($_POST['payment'])) {
     $_SESSION['payment'] = $_POST['payment'];
-// -----
-// Otherwise, if the session's payment-method has not yet been set, save it as an empty value
-// since the order-totals' pre_confirmation_check method expects it to be set for the determination
-// of whether/not a GV/DC credit 'covers' the order's cost.
-//
-} elseif (!isset($_SESSION['payment'])) {
-    $_SESSION['payment'] = '';
 }
 
 // -----
@@ -155,13 +148,9 @@ if ($messageStack->size('checkout') !== 0 || $messageStack->size('checkout_payme
 }
 
 require DIR_WS_CLASSES . 'payment.php';
-
-if (!isset($credit_covers)) {
-    $credit_covers = false;
-}
+$credit_covers = $credit_covers ?? false;
 
 if ($credit_covers === true) {
-    unset($_SESSION['payment']);
     $_SESSION['payment'] = '';
     $payment_title = PAYMENT_METHOD_GV;
 } else {

--- a/includes/modules/pages/checkout_one_confirmation/header_php.php
+++ b/includes/modules/pages/checkout_one_confirmation/header_php.php
@@ -175,6 +175,14 @@ if ($credit_covers === true) {
 $order_totals = $order_total_modules->process();
 
 // -----
+// Check to see if any messages exist for the 'checkout' (issued by credit-class order-totals) or the 'checkout_payment'
+// page; that will also result in a redirect back to the 'checkout_one' main page.
+//
+if ($messageStack->size('checkout') !== 0 || $messageStack->size('checkout_payment') !== 0 || $messageStack->size('redemptions') !== 0) {
+    zen_redirect(zen_href_link(FILENAME_CHECKOUT_ONE, '', 'SSL'));
+}
+
+// -----
 // Determine whether the current payment method requires this confirmation page to
 // be displayed.
 //
@@ -185,8 +193,7 @@ if ($credit_covers === true && strpos(CHECKOUT_ONE_CONFIRMATION_REQUIRED, 'credi
     $confirmation_required = true;
 }
 
-$order_info_mismatch = (($_SESSION['opc_order_hash'] ?? '') !== md5(json_encode($order->info)));
-if ($confirmation_required === false && $order_info_mismatch === true) {
+if (($_SESSION['opc_order_hash'] ?? '') !== md5(json_encode($order->info))) {
     $error = true;
     $checkout_one->debug_message(
         "Order-information mismatch, before and after:\n" .
@@ -194,14 +201,6 @@ if ($confirmation_required === false && $order_info_mismatch === true) {
         json_encode($order->info, JSON_PRETTY_PRINT)
     );
     $messageStack->add_session('checkout_payment', ERROR_NOJS_ORDER_CHANGED, 'error');
-}
-
-// -----
-// Check to see if any messages exist for the 'checkout' (issued by credit-class order-totals) or the 'checkout_payment'
-// page; that will also result in a redirect back to the 'checkout_one' main page.
-//
-if ($messageStack->size('checkout') !== 0 || $messageStack->size('checkout_payment') !== 0) {
-    $error = true;
 }
 
 // -----


### PR DESCRIPTION
Addresses #400.  Essentially, a page re-load is needed if address-related changes are made on the `checkout_one` page ... so that taxes can be recalculated and any zone-specific shipping/payment modules can take their required actions.