### PR TITLE
correct product tax display on shipping change

### DIFF
--- a/includes/classes/ajax/zcAjaxOnePageCheckout.php
+++ b/includes/classes/ajax/zcAjaxOnePageCheckout.php
@@ -24,7 +24,7 @@ class zcAjaxOnePageCheckout extends base
     //
     public function updateShippingSelection()
     {
-        global $checkout_one;
+        global $checkout_one, $order;
 
         // -----
         // Load the One-Page Checkout page's language files. Note that this method also sets the
@@ -95,6 +95,9 @@ class zcAjaxOnePageCheckout extends base
                 }
             }
         }
+        foreach ($order->products as $key => $values) {
+            $productTaxArray[$key] = $values['tax'] . '%';
+        }
 
         // -----
         // Return the re-formatted HTML to be updated into the order's "Totals" section.
@@ -104,6 +107,7 @@ class zcAjaxOnePageCheckout extends base
             'errorMessage' => $error_message,
             'orderTotalHtml' => $order_total_html,
             'total' => $this->formatOrderTotal(),
+            'productTax' => $productTaxArray,
         ];
     }
 

--- a/includes/modules/pages/checkout_one/jquery.checkout_one.js
+++ b/includes/modules/pages/checkout_one/jquery.checkout_one.js
@@ -491,6 +491,14 @@ jQuery(document).ready(function() {
             } else {
                 jQuery('#orderTotalDivs').html(response.orderTotalHtml);
                 jQuery('#current-order-total').val(response.total);
+                var index = 0;
+                jQuery('.productTax').each(function() {
+                    if (index < Object.keys(response.productTax).length) {
+                        var key = Object.keys(response.productTax)[index];
+                        jQuery(this).text(response.productTax[key]);
+                        index++;
+                    }
+                });
             }
         });
     });

--- a/includes/templates/template_default/templates/tpl_modules_opc_shopping_cart.php
+++ b/includes/templates/template_default/templates/tpl_modules_opc_shopping_cart.php
@@ -66,7 +66,7 @@ for ($i = 0, $n = count($order->products); $i < $n; $i++) {
   // display tax info if exists
     if (sizeof ($order->info['tax_groups']) > 1)  { 
 ?>
-          <td class="cartTotalDisplay"><?php echo zen_display_tax_value($order->products[$i]['tax']); ?>%</td>
+          <td class="cartTotalDisplay productTax"><?php echo zen_display_tax_value($order->products[$i]['tax']); ?>%</td>
 <?php
     }  // endif tax info display  
 ?>


### PR DESCRIPTION
pursuant to the issue here:

https://github.com/lat9/local_sales_tax/issues/9

and specifically [this comment](https://github.com/lat9/local_sales_tax/issues/9#:~:text=if%20you%20pause,9.75%25%20NOT%2010.25%25.); this PR correctly repopulates the product tax rate on the product line items on a shipping selection change.