### PR TITLE
Fix event handler and checkoutOneGuestInfo duplication

### DIFF
--- a/includes/modules/pages/checkout_one/jquery.checkout_one.js
+++ b/includes/modules/pages/checkout_one/jquery.checkout_one.js
@@ -753,12 +753,8 @@ jQuery(document).ready(function() {
             }
             if (which == 'ship') {
                 jQuery(document).on('change', '#checkoutOneShipto input, #checkoutOneShipto select:not(#select-address-ship)', changeShippingFields);
-                jQuery(document).on('click', '#opc-ship-cancel', restoreShipping);
-                jQuery(document).on('click', '#opc-ship-save', saveShipping);
             } else {
                 jQuery(document).on('change', '#checkoutOneBillto input, #checkoutOneBillto select:not(#select-address-bill)', changeBillingFields);
-                jQuery(document).on('click', '#opc-bill-cancel', restoreBilling);
-                jQuery(document).on('click', '#opc-bill-save', saveBilling);
             }
         });
     }

--- a/includes/modules/pages/checkout_one/jquery.checkout_one.js
+++ b/includes/modules/pages/checkout_one/jquery.checkout_one.js
@@ -897,7 +897,7 @@ jQuery(document).ready(function() {
             //
             checkForRedirect(response);
 
-            jQuery('#checkoutOneGuestInfo').html(response.infoHtml);
+            jQuery('#checkoutOneGuestInfo').replaceWith(response.infoHtml);
             restoreAddressValues('bill', '#checkoutOneBillto');
         });
     }

--- a/includes/modules/pages/checkout_one/jquery.checkout_one.js
+++ b/includes/modules/pages/checkout_one/jquery.checkout_one.js
@@ -751,11 +751,6 @@ jQuery(document).ready(function() {
             if (typeof initializeStateZones != 'undefined') {
                 initializeStateZones();
             }
-            if (which == 'ship') {
-                jQuery(document).on('change', '#checkoutOneShipto input, #checkoutOneShipto select:not(#select-address-ship)', changeShippingFields);
-            } else {
-                jQuery(document).on('change', '#checkoutOneBillto input, #checkoutOneBillto select:not(#select-address-bill)', changeBillingFields);
-            }
         });
     }
 


### PR DESCRIPTION
Hitting "edit billing" or "edit shipping" and then cancelling would add another event listener without canceling prior ones. Clicking would trigger all of them at the same time, adding more requests to the server each time until the page refreshed.
Here's a video showing my network requests (cleared after page load) and console to illustrate:
https://files.hucar.io/issues/opc1.mp4

In a similar vein, performing the same cancellation would also duplicate the guest information block (the first time). Here's a video where I've applied a 3px border to `#checkoutOneGuestInfo` to make this clearer:
https://files.hucar.io/issues/opc2.mp4